### PR TITLE
Updated compose.sh to check for no args and docker volumes and ports

### DIFF
--- a/docker-compose-files/compose.sh
+++ b/docker-compose-files/compose.sh
@@ -8,6 +8,11 @@ if [[ $(id -u) = 0 ]]; then
   exit 1
 fi
 
+if [[ $# -eq 0 ]] ; then
+    echo 'No arguments provided. Run with -h for help.'
+    exit 0
+fi
+
 PROFILE_ARG=
 BUILD_ARG=
 
@@ -109,11 +114,11 @@ echo "GROUP_ID=$(id -g)" >> $topdir/.env
 
 case $1 in
   stop)
-    docker-compose --project-directory $topdir -f $scriptdir/docker-compose.yml rm -f
+    docker-compose --project-directory $topdir -f $scriptdir/docker-compose.yml rm -f -d
     ;;
 
   start)
-    docker-compose --project-directory $topdir -f $scriptdir/docker-compose.yml ${PROFILE_ARG} up ${BUILD_ARG}
+    docker-compose --verbose --project-directory $topdir -f $scriptdir/docker-compose.yml ${PROFILE_ARG} up ${BUILD_ARG} -d
     ;;
 
   *)

--- a/docker-compose-files/docker-compose.yml
+++ b/docker-compose-files/docker-compose.yml
@@ -71,7 +71,8 @@ networks:
 volumes:
   influxdb-storage:
   grafana-storage:
-  prometheus_data:
+  prometheus-data:
+  mysqldb-volume:
 
 services:
   activemq:
@@ -80,6 +81,9 @@ services:
     profiles: *optional-disable
     networks:
       - private
+    ports:
+      - "61613:61613"
+      - "8161:8161"
 
   mysqldb:
     container_name: mysqldb
@@ -92,8 +96,8 @@ services:
       MYSQL_ROOT_PASSWORD: "bananas"   #sample reference - specify configured credentials
     networks:
       - private
-    #mount deployed mysql filesystem location for persistance
-
+    volumes:
+      - mysqldb-volume:/var/lib/mysql:rw
 
   configui:
     <<: *refdaemon
@@ -262,7 +266,7 @@ services:
         source: ${PWD}/cmd/prometheuspump/prometheus.yml
         target: /config/prometheus.yml
         read_only: true
-      - prometheus_data:/prometheus
+      - prometheus-data:/prometheus
     environment:
       - node.name=prometheus
       - PROMETHEUS_DB=poweredge_telemetry_metrics


### PR DESCRIPTION
- Made it so compose.sh will check for no args, run in daemon mode, and default to being verbose. I thought the verbosity will be nice because it will help people with troubleshooting but you could get rid of that
- Added the mysql named volume, standardized volume names, and exposed required ports via port forwarding